### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/a-deploy/charts/vault-chart/templates/vault-unseal-job.yaml
+++ b/a-deploy/charts/vault-chart/templates/vault-unseal-job.yaml
@@ -47,7 +47,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: kubectl
-          image: bitnami/kubectl:1.33.4
+          image: soldevelo/kubectl:1.33.4
           env:
             - name: VAULT_UNSEAL_KEY
               valueFrom:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/kubectl:1.33.4` → [`soldevelo/kubectl:1.33.4`](https://hub.docker.com/r/soldevelo/kubectl)